### PR TITLE
Use value of pixel in `DrawTarget`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@ where
         I: IntoIterator<Item = Pixel<Self::Color>>,
     {
         for Pixel(Point { x, y }, color) in pixels.into_iter() {
-            self.set_pixel(x as usize, y as usize, true);
+            self.set_pixel(x as usize, y as usize, color.is_on());
         }
         Ok(())
     }


### PR DESCRIPTION
This allows images to draw correctly by clearing pixels as well as setting them.

Resolves #1